### PR TITLE
Updates SSHKit to version 0.3.0

### DIFF
--- a/lib/netconf.ex
+++ b/lib/netconf.ex
@@ -41,7 +41,7 @@ defmodule Netconf do
 
   def initialize_netconf(conn) do
     {:ok, channel} = SSHKit.SSH.Channel.open(conn)
-    :ok = SSHKit.SSH.Channel.subsystem(channel, "netconf")
+    :success = SSHKit.SSH.Channel.subsystem(channel, "netconf")
     :ok = SSHKit.SSH.Channel.send(channel, @hello)
 
     hello_message = get_message(channel, :eom)

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Netconf.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:sshkit, github: "derekkraan/sshkit.ex", branch: "expose_subsystem"}
+      {:sshkit, "~> 0.3"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "sshkit": {:git, "https://github.com/derekkraan/sshkit.ex.git", "26079a161dab7ceb2430189d986cb6f575a66e53", [branch: "expose_subsystem"]},
+  "sshkit": {:hex, :sshkit, "0.3.0", "4c100e3c3ebd261b6b7de811ade713f425fb06eb730a96d583da18d29a6fca26", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This version contains the subsystem support which was in the fork before.

I believe there's a few more things that need to be done but with this merged in the dependencies are at least retrievable again :)